### PR TITLE
Fixed issues with end-point URLs and temp filename

### DIFF
--- a/src/Client/ConsignmentClient.php
+++ b/src/Client/ConsignmentClient.php
@@ -64,7 +64,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 			]
 		);
 
-		$response = $this->httpClient->request('POST', self::PATH_SEND, $options);
+		$response = $this->httpClient->request('POST', $this->config['http']['base_uri'] . self::PATH_SEND, $options);
 		unlink($tmpFile);
 
 		return $response;
@@ -98,7 +98,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 			]
 		);
 
-		return $this->httpClient->request('POST', self::PATH_DETAIL, $options);
+		return $this->httpClient->request('POST', $this->config['http']['base_uri'] . self::PATH_DETAIL, $options);
 	}
 
 	public function printLabel(string $trackingNumber): ResponseInterface
@@ -120,7 +120,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 			]
 		);
 
-		return $this->httpClient->request('POST', self::PATH_LABEL, $options);
+		return $this->httpClient->request('POST', $this->config['http']['base_uri'] . self::PATH_LABEL, $options);
 	}
 
 	public function cancel(?string $id = null): ResponseInterface
@@ -145,7 +145,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 			$options['form_params']['zasilka'] = $id;
 		}
 
-		return $this->httpClient->request('POST', self::PATH_CANCEL, $options);
+		return $this->httpClient->request('POST', $this->config['http']['base_uri'] . self::PATH_CANCEL, $options);
 	}
 
 	public function fetchEnum(bool $payoffType, bool $paymentType, bool $iso): ResponseInterface
@@ -184,7 +184,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 
 		$options['form_params']['typciselniku'] = $type;
 
-		return $this->httpClient->request('POST', self::PATH_ENUMS, $options);
+		return $this->httpClient->request('POST', $this->config['http']['base_uri'] . self::PATH_ENUMS, $options);
 	}
 
 	private function createTmpFile(string $path, string $content): void

--- a/src/Client/ConsignmentClient.php
+++ b/src/Client/ConsignmentClient.php
@@ -35,7 +35,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 
 	public function send(Consignment $consignment): ResponseInterface
 	{
-		$tmpFile = $this->getTmpDir() . bin2hex(random_bytes(12)) . '.xml';
+		$tmpFile = tempnam($this->getTmpDir(), 'CZPost') . ".xml";
 		$xml = $this->requestFactory->create($consignment);
 		$this->createTmpFile($tmpFile, $xml->saveXML());
 

--- a/src/Client/ConsignmentClient.php
+++ b/src/Client/ConsignmentClient.php
@@ -35,7 +35,7 @@ class ConsignmentClient extends AbstractCpostHttpClient
 
 	public function send(Consignment $consignment): ResponseInterface
 	{
-		$tmpFile = tempnam($this->getTmpDir(), 'CZPost') . ".xml";
+		$tmpFile = tempnam($this->getTmpDir(), 'CZPost') . '.xml';
 		$xml = $this->requestFactory->create($consignment);
 		$this->createTmpFile($tmpFile, $xml->saveXML());
 


### PR DESCRIPTION
Hi there,
didn't have time and priorities for test this API. No I have to implement it and I see it's unusable. There are several issues which disable you from using this package.

1. Temp filename is wrong. Maybe only on linux but if you not fill dir in config, path of file look like `/tmp1sa1d56s.xml`. This cause _Permission denied_ because you are trying write file into disk root. So PR let this on php native functions.
2. Login configuration is wrong. If you fill configuration like doc saying, array in `'http' => 'auth'` looks like `['','','dreplech','dreplech']` and you are using offsets so username and password is from defaults. I don't have idea how to make hotfix. I'm inheriting Extension class so I override `$defaults` to`'auth' => []`.
3. End-point URLs are wrong. You are using only constants in request so `base_uri` is never used. Fix in this PR