### PR TITLE
Fix ''Array to string conversion" error for normal letter

### DIFF
--- a/src/Entity/Dispatch.php
+++ b/src/Entity/Dispatch.php
@@ -192,7 +192,7 @@ final class Dispatch
 			throw new InvalidStateException('Missing dispatch\'s  "id" or "kod_objednavky" key.');
 		}
 
-		return new self($id, (string) $data['podacicislo']);
+		return new self($id, (is_array($data['podacicislo']) && count($data['podacicislo']) == 0) ? '' : (string) $data['podacicislo']);
 	}
 
 }


### PR DESCRIPTION
For type 195 (OBYČEJNÉ PSANÍ PRIORITNĚ), empty array is returned in the deserialized 'podacicislo' field, thus needs to be converted to empty string.